### PR TITLE
Updated tools.json to include Meterian in the list

### DIFF
--- a/tool-center/tools.json
+++ b/tool-center/tools.json
@@ -963,5 +963,18 @@
       "opensource",
       "build-integration"
     ]
+  },
+  {
+    "name": "Meterian BOSS scanner",
+    "publisher": "Meterian",
+    "description": "Software composition analysis for codebases providing precise and comprehensive CycloneDX SBOMs for open source and private source code projects. Supports all major ecosystems Java, NodeJS, .NET, Go, Rust, Swift, Python, Ruby, PHP, C/C++, Perl",
+    "websiteUrl": " https://meterian.io/products/boss",
+    "categories": [
+      "proprietary",
+      "github-action",
+      "bitbucket-pipe",
+      "azure-devops-extension",
+      "build-integration"
+    ]
   }
 ]


### PR DESCRIPTION
Hi team, Bruno CTO from Meterian. We'd be glad to have our product added to the list. We generate CycloneDX SBOMs and we have a few integrations available. In terms of categories, I saw "github-action", and I added also "bitbucket-pipe" and "azure-devops-extension", as they were not there and we support those. Please feel free to send this PR back to me to remove them if they are not useful :)